### PR TITLE
Add Force 6 report generator page

### DIFF
--- a/src/pages/PaperworkTools/code1Reports.html
+++ b/src/pages/PaperworkTools/code1Reports.html
@@ -74,7 +74,7 @@
                 </div>
 
                 <div class="sidebar-item dropdown-item">
-                    <h3>Force 6 Reports</h3>
+                    <a href="./force6Reports.html"><h3>Force 6 Reports</h3></a>
                 </div>
 
                 <div class="sidebar-item dropdown-item">

--- a/src/pages/PaperworkTools/force6Reports.html
+++ b/src/pages/PaperworkTools/force6Reports.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Duty Reports</title>
+    <title>Force 6 Reports</title>
     <script src="/src/index.js" type="module"></script>
-    <script src="/src/scripts/reports/dutyReports.js" type="module"></script>
+    <script src="/src/scripts/reports/force6Reports.js" type="module"></script>
     <link rel="stylesheet" href="/src/styles/Global.css">
     <link rel="stylesheet" href="/src/styles/Sidebar.css">
     <link rel="stylesheet" href="/src/styles/reports/DutyReprots.css">
@@ -14,7 +14,7 @@
     <div class="container flex">
         <div class="sidebar">
             <div class="sidebar-header flex">
-                <img src="/src/img/DOC.png" alt="DOC Logo" width="40px"> 
+                <img src="/src/img/DOC.png" alt="DOC Logo" width="40px">
                 <h3>SADOC TOOLS</h3>
             </div>
             <hr>
@@ -66,7 +66,7 @@
             <!--Paperwork Tools Dropdown items-->
             <div class="dropdown d-none" id="paperWorkTools">
                 <div class="sidebar-item dropdown-item">
-                    <h3>Duty Reports</h3>
+                    <a href="./dutyReports.html"><h3>Duty Reports</h3></a>
                 </div>
 
                 <div class="sidebar-item dropdown-item">
@@ -74,7 +74,7 @@
                 </div>
 
                 <div class="sidebar-item dropdown-item">
-                    <a href="./force6Reports.html"><h3>Force 6 Reports</h3></a>
+                    <h3>Force 6 Reports</h3>
                 </div>
 
                 <div class="sidebar-item dropdown-item">
@@ -85,99 +85,107 @@
             <div class="sidebar-item">
                 <a href="https://gov.eclipse-rp.net/viewforum.php?f=660" target="_blank" class="sidebar-item"><h3>Government Website</h3></a>
             </div>
-            
+
         </div>
 
         <div class="content">
             <div class="content-header">
-                <h1>Duty Reports</h1>
+                <h1>Force 6 Reports</h1>
             </div>
 
             <div class="content-body ">
-                <form action="" id="DutyReportsForm">
-                    <h3>Duty Report Details</h3>
+                <form action="" id="Force6ReportsForm">
+                    <h3>Force 6 Report Details</h3>
 
                     <div class="form-group">
                         <div class="label">
-                            <label for="Date">Date of Report:</label>
+                            <label for="Date">Date:</label>
                         </div>
                         <div class="inputs">
-                            <input type="date" name="DateOfReport" id="DateOfReport">
+                            <input type="date" name="Date" id="Date">
                         </div>
                     </div>
 
                     <div class="form-group">
                         <div class="label">
-                            <label for="StartOfShift">Start of Shift:</label>
+                            <label for="OfficerName">Officers name:</label>
                         </div>
                         <div class="inputs">
-                            <input type="time" name="StartOfShift" id="StartOfShift">
+                            <input type="text" name="OfficerName" id="OfficerName">
                         </div>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group duty-logs-section">
                         <div class="label">
-                            <label for="10-15s">10-15s Processed:</label>
+                            <label for="NewWitness">Any witnesses? (Officers, other inmates, visitors)</label>
                         </div>
-                        <div class="inputs">
-                            <input type="number" name="10-15s" id="10-15s">
-                            
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <div class="label">
-                            <label for="EndOfShift">End of Shift:</label>
-                        </div>
-                        <div class="inputs">
-                            <input type="time" name="EndOfShift" id="EndOfShift">
-                        </div>
-                    </div>
-
-                    <div class="duty-logs-section">
-                        <h3>General Duty Logs</h3>
-                        <div id="DutyLogsContainer" id="GeneralDutyLogs">
-                            <!--Logs will go here.-->
-                            <div class="duty-log" id="">
-                                <p>Did something cool today woo</p>
-                                <button type="button" class="deleteLogBtn">&times;</button>
-                            </div>
-                        </div>
-
+                        <div id="WitnessesContainer"></div>
                         <div class="addLog flex">
-                            <input type="text" name="NewDutyLog" id="NewDutyLog" placeholder="General Duties performed during your watch">
-                            <button type="button" id="addDutyLogBtn">Add Log</button>
+                            <input type="text" id="NewWitness" placeholder="Name of witness">
+                            <button type="button" id="addWitnessBtn">Add Witness</button>
                         </div>
                     </div>
-                    <hr>
 
-                    <div class="duty-logs-section">
-                        <h3>Divisional Duty Logs</h3>
-                        <div id="DivisionalDutyLogs">
-                            <!--Logs will go here.-->
-                            <div class="duty-log" id="">
-                                <p>Did something cool today woo</p>
-                                <button type="button" class="deleteLogBtn">&times;</button>
-                            </div>
+                    <div class="form-group">
+                        <div class="label">
+                            <label for="RankBadge">Rank & Badge Number:</label>
                         </div>
+                        <div class="inputs">
+                            <input type="text" name="RankBadge" id="RankBadge">
+                        </div>
+                    </div>
 
-                        <div class="addLog flex">
-                            <input type="text" name="NewDivisionalLog" id="NewDivisionalLog" placeholder="Divisional Duties performed during your watch">
-                            <button type="button" id="addDivisionalLogBtn">Add Log</button>
+                    <div class="form-group">
+                        <div class="label">
+                            <label for="Weapons">Lethal weapon(s) utilized for force 6:</label>
+                        </div>
+                        <div class="inputs">
+                            <input type="text" name="Weapons" id="Weapons">
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="label">
+                            <label for="Situation">Situation:</label>
+                        </div>
+                        <div class="inputs">
+                            <textarea name="Situation" id="Situation" rows="5"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="label">
+                            <label for="Conclusion">Conclusion:</label>
+                        </div>
+                        <div class="inputs">
+                            <textarea name="Conclusion" id="Conclusion"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="label">
+                            <label for="BodycamAttachment">Bodycam footage attachment:</label>
+                        </div>
+                        <div class="inputs">
+                            <input type="text" name="BodycamAttachment" id="BodycamAttachment">
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="label">
+                            <label for="BodycamProof">Proof of Bodycam RP (image URL):</label>
+                        </div>
+                        <div class="inputs">
+                            <input type="text" name="BodycamProof" id="BodycamProof">
                         </div>
                     </div>
                 </form>
                 <button id="GenerateOutput" style="margin-bottom: 10px;">Generate and Copy</button>
                 <div class="output">
                     <h3>Output Will Go here</h3>
-                    <textarea type="textarea" readonly id="Output">
+                    <textarea type="textarea" readonly id="Output"></textarea>
                 </div>
             </div>
-
-            
-
-
-    
 
         </div>
     </div>

--- a/src/scripts/reports/deletelog.js
+++ b/src/scripts/reports/deletelog.js
@@ -1,9 +1,9 @@
-import { divLogs, supervisorLogs, dutyLogs, storeData, notableOfficers, code1Witnesses } from "../utils/DataHandling.js";
+import { divLogs, supervisorLogs, dutyLogs, storeData, notableOfficers, code1Witnesses, force6Witnesses } from "../utils/DataHandling.js";
 import { renderDutyLogs, renderDivLogs, renderSupervisorDutyLogs, renderNotableOfficers, renderWitnesses } from "../utils/DOMstuff.js";
 
 /**
  * Remove a log entry from the specified collection and update storage and UI.
- * @param {"duty"|"div"|"Supduty"|"noteOfficers"|"witness"} logType - The type of log list to modify.
+ * @param {"duty"|"div"|"Supduty"|"noteOfficers"|"witness"|"force6Witness"} logType - The type of log list to modify.
  * @param {string} logID - The unique identifier of the log to delete.
  */
 export function deleteLog(logType, logID) {
@@ -57,6 +57,16 @@ export function deleteLog(logType, logID) {
         code1Witnesses.splice(index, 1);
         storeData();
         renderWitnesses();
+    } else if (logType == "force6Witness") {
+        let logtoDel = force6Witnesses.find((log) => {
+            if (log.id == logID)
+                return log;
+        });
+
+        let index = force6Witnesses.indexOf(logtoDel);
+        force6Witnesses.splice(index, 1);
+        storeData();
+        renderWitnesses(force6Witnesses, "force6Witness");
     }
 }
 

--- a/src/scripts/reports/force6Reports.js
+++ b/src/scripts/reports/force6Reports.js
@@ -1,0 +1,73 @@
+import { Log } from "../base/LogClasses.js";
+import { force6Witnesses, retrieveData, storeData } from "../utils/DataHandling.js";
+import { renderWitnesses } from "../utils/DOMstuff.js";
+
+const generateBtn = document.getElementById("GenerateOutput");
+const addWitnessBtn = document.getElementById("addWitnessBtn");
+const witnessInput = document.getElementById("NewWitness");
+
+retrieveData();
+renderWitnesses(force6Witnesses, "force6Witness");
+
+const fields = ["Date", "OfficerName", "RankBadge", "Weapons", "Situation", "Conclusion", "BodycamAttachment", "BodycamProof"];
+fields.forEach(id => {
+    const elem = document.getElementById(id);
+    const stored = localStorage.getItem(`force6_${id}`);
+    if (stored) {
+        elem.value = stored;
+    }
+    elem.addEventListener("input", () => {
+        localStorage.setItem(`force6_${id}`, elem.value);
+    });
+});
+
+export function addWitness() {
+    let text = witnessInput.value.trim();
+    if (!text) return;
+    let log = new Log(text);
+    force6Witnesses.push(log);
+    renderWitnesses(force6Witnesses, "force6Witness");
+    storeData();
+    witnessInput.value = "";
+}
+
+function generate() {
+    const outputArea = document.getElementById("Output");
+    const date = document.getElementById("Date").value;
+    const officerName = document.getElementById("OfficerName").value;
+    const rankBadge = document.getElementById("RankBadge").value;
+    const weapons = document.getElementById("Weapons").value;
+    const situation = document.getElementById("Situation").value;
+    const conclusion = document.getElementById("Conclusion").value;
+    const bodycamAttachment = document.getElementById("BodycamAttachment").value;
+    const bodycamProof = document.getElementById("BodycamProof").value;
+    const witnessesTxt = force6Witnesses.map(log => "[*]" + log.text).join("\n");
+
+    const outputText = `[img]https://i.imgur.com/SCK366b.png[/img]\n` +
+        `[docsubtitle]Force 6 Report Details[/docsubtitle]\n` +
+        `[divbox=white]\n[b]Date:[/b] ${date}\n` +
+        `[hr]\n[ol][/ol]\n[b]Officers name:[/b] ${officerName}\n` +
+        `[hr]\n[ol][/ol]\n[b]Any witnesses? (Officers, other inmates, visitors)[/b]\n[list]\n${witnessesTxt}\n[/list]\n` +
+        `[hr]\n[ol][/ol]\n[b]Rank & Badge Number:[/b] ${rankBadge}\n` +
+        `[hr]\n[ol][/ol]\n[b]Lethal weapon(s) utilized for force 6:[/b] ${weapons}\n` +
+        `[hr]\n[ol][/ol]\n[b]Situation:[/b] ${situation}\n` +
+        `[hr]\n[ol][/ol]\n[b]Conclusion:[/b] ${conclusion}\n` +
+        `[hr]\n[ol][/ol]\n[b]Bodycam footage attachment:[/b] ${bodycamAttachment}\n` +
+        `[hr]\n[ol][/ol]\n[ooc]\n[b][color=#FF0000]MANDATORY:[/color][/b][spoiler=Proof of Bodycam RP][img]${bodycamProof}[/img][/spoiler]\n[/ooc]\n[/divbox]\n[img]https://i.imgur.com/EYwU3XA.png[/img]`;
+
+    outputArea.value = outputText;
+    outputArea.select();
+    document.execCommand("copy");
+
+    force6Witnesses.splice(0);
+    storeData();
+    renderWitnesses(force6Witnesses, "force6Witness");
+    fields.forEach(id => {
+        const elem = document.getElementById(id);
+        elem.value = "";
+        localStorage.removeItem(`force6_${id}`);
+    });
+}
+
+addWitnessBtn.addEventListener("click", addWitness);
+generateBtn.addEventListener("click", generate);

--- a/src/scripts/utils/DOMstuff.js
+++ b/src/scripts/utils/DOMstuff.js
@@ -127,14 +127,17 @@ export function renderDivLogs() {
 }
 
 /**
- * Render Code 1 witness entries to the UI.
+ * Render witness entries to the UI.
+ * Defaults to Code 1 witnesses but can render other lists.
+ * @param {Array} witnessArr - collection of witness logs to render.
+ * @param {"witness"|"force6Witness"} deleteType - identifier passed to deleteLog.
  */
-export function renderWitnesses() {
+export function renderWitnesses(witnessArr = code1Witnesses, deleteType = "witness") {
     const witnessesContainer = document.getElementById("WitnessesContainer");
     if (!witnessesContainer) return;
     witnessesContainer.innerHTML = "";
 
-    code1Witnesses.forEach((log) => {
+    witnessArr.forEach((log) => {
         let witnessLog = document.createElement("div");
         let text = document.createElement("p");
         let deleteBtn = document.createElement("button");
@@ -148,7 +151,7 @@ export function renderWitnesses() {
 
         deleteBtn.addEventListener("click", (e) => {
             let logID = e.target.dataset.id;
-            deleteLog("witness", logID);
+            deleteLog(deleteType, logID);
         });
 
         witnessLog.appendChild(text);

--- a/src/scripts/utils/DataHandling.js
+++ b/src/scripts/utils/DataHandling.js
@@ -7,6 +7,7 @@ export let divLogs = [];
 export let supervisorLogs = [];
 export let notableOfficers = [];
 export let code1Witnesses = [];
+export let force6Witnesses = [];
 
 /**
  * Load saved logs from localStorage into memory.
@@ -17,6 +18,7 @@ export function retrieveData() {
     const storedSupLogs = localStorage.getItem("supLogs");
     const storedNotableOfficers = localStorage.getItem("noteOfficers");
     const storedWitnesses = localStorage.getItem("code1Witnesses");
+    const storedForce6Witnesses = localStorage.getItem("force6Witnesses");
 
     if (storedDutyLogs) {
         dutyLogs = JSON.parse(storedDutyLogs);
@@ -45,6 +47,11 @@ export function retrieveData() {
     } else {
         code1Witnesses = [];
     }
+    if (storedForce6Witnesses) {
+        force6Witnesses = JSON.parse(storedForce6Witnesses);
+    } else {
+        force6Witnesses = [];
+    }
 }
 
 /**
@@ -56,5 +63,6 @@ export function storeData() {
     localStorage.setItem("supLogs", JSON.stringify(supervisorLogs));
     localStorage.setItem("noteOfficers", JSON.stringify(notableOfficers));
     localStorage.setItem("code1Witnesses", JSON.stringify(code1Witnesses));
+    localStorage.setItem("force6Witnesses", JSON.stringify(force6Witnesses));
 }
 


### PR DESCRIPTION
## Summary
- implement Force 6 report page with form fields and output generator
- allow separate witness tracking for Force 6 reports
- update navigation links to include Force 6 reports page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c81489a0348330ad9494658ded5e0f