### PR TITLE
Prevent overflow in duty log entries

### DIFF
--- a/src/styles/reports/DutyReprots.css
+++ b/src/styles/reports/DutyReprots.css
@@ -63,6 +63,15 @@ input:focus, textarea:focus, select:focus {
     transition: transform 0.2s ease;
 }
 
+.duty-log p {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: 10px;
+}
+
 .duty-log:hover {
     transform: translateX(5px);
 }
@@ -77,6 +86,7 @@ input:focus, textarea:focus, select:focus {
     align-items: center;
     justify-content: center;
     transition: background-color 0.3s ease;
+    flex-shrink: 0;
 }
 
 .deleteLogBtn:hover {


### PR DESCRIPTION
## Summary
- Truncate long duty log text with ellipsis and keep delete button visible
- Prevent delete button from shrinking in log entries

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c81907ead48330a13c68e450bf803d