### PR TITLE
Persist duty report fields and fix supervisor links

### DIFF
--- a/src/pages/PaperworkTools/code1Reports.html
+++ b/src/pages/PaperworkTools/code1Reports.html
@@ -56,7 +56,7 @@
             </div>-->
 
         <div class="sidebar-item">
-          <a href="pages/SupervisorTools/supervisorDutyReports.html"
+          <a href="../SupervisorTools/supervisorDutyReports.html"
             ><h3>Supervisor Tools</h3></a
           >
         </div>

--- a/src/pages/PaperworkTools/dutyReports.html
+++ b/src/pages/PaperworkTools/dutyReports.html
@@ -57,7 +57,7 @@
 
 
             <div class="sidebar-item">
-                <a href="pages/SupervisorTools/supervisorDutyReports.html"><h3>Supervisor Tools</h3></a> 
+                <a href="../SupervisorTools/supervisorDutyReports.html"><h3>Supervisor Tools</h3></a>
             </div>
 
             <div class="sidebar-item dropdown-toggle dropdown-ptools">

--- a/src/pages/PaperworkTools/force6Reports.html
+++ b/src/pages/PaperworkTools/force6Reports.html
@@ -56,7 +56,7 @@
             </div>-->
 
         <div class="sidebar-item">
-          <a href="pages/SupervisorTools/supervisorDutyReports.html"
+          <a href="../SupervisorTools/supervisorDutyReports.html"
             ><h3>Supervisor Tools</h3></a
           >
         </div>

--- a/src/pages/PaperworkTools/solitaryReports.html
+++ b/src/pages/PaperworkTools/solitaryReports.html
@@ -59,7 +59,7 @@
             </div>-->
 
         <div class="sidebar-item">
-          <a href="pages/SupervisorTools/supervisorDutyReports.html"
+          <a href="../SupervisorTools/supervisorDutyReports.html"
             ><h3>Supervisor Tools</h3></a
           >
         </div>

--- a/src/scripts/reports/dutyReports.js
+++ b/src/scripts/reports/dutyReports.js
@@ -12,9 +12,38 @@ const divLogInput = document.getElementById("NewDivisionalLog");
 const addDivisionalLogBtn = document.getElementById("addDivisionalLogBtn");
 const generateBtn = document.getElementById("GenerateOutput");
 
+// Duty report form fields
+const dateInput = document.getElementById("DateOfReport");
+const startInput = document.getElementById("StartOfShift");
+const ten15Input = document.getElementById("10-15s");
+const endInput = document.getElementById("EndOfShift");
+
+// Only run field persistence on the duty report page
+if (ten15Input) {
+    loadInputs();
+    dateInput.addEventListener("change", storeInputs);
+    startInput.addEventListener("change", storeInputs);
+    ten15Input.addEventListener("change", storeInputs);
+    endInput.addEventListener("change", storeInputs);
+}
+
 retrieveData();
 renderDutyLogs();
 renderDivLogs();
+
+function loadInputs() {
+    dateInput.value = localStorage.getItem("dutyDate") || "";
+    startInput.value = localStorage.getItem("dutyStart") || "";
+    ten15Input.value = localStorage.getItem("dutyTen15s") || "";
+    endInput.value = localStorage.getItem("dutyEnd") || "";
+}
+
+function storeInputs() {
+    localStorage.setItem("dutyDate", dateInput.value);
+    localStorage.setItem("dutyStart", startInput.value);
+    localStorage.setItem("dutyTen15s", ten15Input.value);
+    localStorage.setItem("dutyEnd", endInput.value);
+}
 
 /**
  * Add a new general duty log entry based on user input.
@@ -53,10 +82,10 @@ export function addDivLog() {
  */
 function generate() {
     const outputArea = document.getElementById("Output");
-    let reportDate = document.getElementById("DateOfReport").value;
-    let startOfShift = document.getElementById("StartOfShift").value;
-    let ten15s = document.getElementById("10-15s").value;
-    let endOfShift = document.getElementById("EndOfShift").value;
+    let reportDate = dateInput.value;
+    let startOfShift = startInput.value;
+    let ten15s = ten15Input.value;
+    let endOfShift = endInput.value;
 
     let dutyLogstxt = dutyLogs.map(log => "[*]" + log.text).join("\n");
     let divLogstxt = divLogs.map(log => "[*]" + log.text).join("\n");
@@ -114,10 +143,23 @@ function generate() {
     dutyLogs.splice(0);
     divLogs.splice(0);
     storeData();
+
+    // Clear stored inputs
+    localStorage.removeItem("dutyDate");
+    localStorage.removeItem("dutyStart");
+    localStorage.removeItem("dutyTen15s");
+    localStorage.removeItem("dutyEnd");
+
+    dateInput.value = "";
+    startInput.value = "";
+    ten15Input.value = "";
+    endInput.value = "";
     //window.open("https://gov.eclipse-rp.net/viewforum.php?f=1180","_blank");
 }
 
-generateBtn.addEventListener("click", generate);
+if (ten15Input) {
+    generateBtn.addEventListener("click", generate);
+}
 addDutyLogBtn.addEventListener("click", addDutyLog);
 addDivisionalLogBtn.addEventListener("click", addDivLog);
 

--- a/src/scripts/reports/supervisorDutyReports.js
+++ b/src/scripts/reports/supervisorDutyReports.js
@@ -13,11 +13,33 @@ const notableOfficersInput = document.getElementById("NewNotableOfficer");
 const addNotableOfficerBtn = document.getElementById("addNotableOfficersBtn");
 const generateBtn = document.getElementById("GenerateOutput");
 
+// Supervisor duty report form fields
+const dateInput = document.getElementById("DateOfReport");
+const startInput = document.getElementById("StartOfShift");
+const endInput = document.getElementById("EndOfShift");
+
+loadInputs();
+dateInput.addEventListener("change", storeInputs);
+startInput.addEventListener("change", storeInputs);
+endInput.addEventListener("change", storeInputs);
+
 retrieveData();
 renderDutyLogs();
 renderSupervisorDutyLogs();
 renderNotableOfficers();
 renderDivLogs();
+
+function loadInputs() {
+    dateInput.value = localStorage.getItem("supDate") || "";
+    startInput.value = localStorage.getItem("supStart") || "";
+    endInput.value = localStorage.getItem("supEnd") || "";
+}
+
+function storeInputs() {
+    localStorage.setItem("supDate", dateInput.value);
+    localStorage.setItem("supStart", startInput.value);
+    localStorage.setItem("supEnd", endInput.value);
+}
 
 /**
  * Add a new supervisor duty log.
@@ -56,9 +78,9 @@ function addNotableOfficer() {
  */
 function generate() {
     const outputArea = document.getElementById("Output");
-    let reportDate = document.getElementById("DateOfReport").value;
-    let startOfShift = document.getElementById("StartOfShift").value;
-    let endOfShift = document.getElementById("EndOfShift").value;
+    let reportDate = dateInput.value;
+    let startOfShift = startInput.value;
+    let endOfShift = endInput.value;
 
     let dutyLogstxt = dutyLogs.map(log => "[*]" + log.text).join("\n");
     let divLogstxt = divLogs.map(log => "[*]" + log.text).join("\n");
@@ -129,6 +151,15 @@ function generate() {
     supervisorLogs.splice(0);
     notableOfficers.splice(0);
     storeData();
+    
+    // Clear stored inputs
+    localStorage.removeItem("supDate");
+    localStorage.removeItem("supStart");
+    localStorage.removeItem("supEnd");
+
+    dateInput.value = "";
+    startInput.value = "";
+    endInput.value = "";
     //window.open("https://gov.eclipse-rp.net/viewforum.php?f=1180","_blank");
 }
 


### PR DESCRIPTION
## Summary
- persist duty report and supervisor duty report form values across reloads
- correct supervisor tools link in paperwork pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c83af1d224833092208cffed4e019e