### PR TITLE
Add Set UTC controls for date inputs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,77 @@ const configureDropdownToggle = (toggle, dropdown) => {
     });
 };
 
+const pad = value => String(value).padStart(2, "0");
+
+const getInputType = input => (input.getAttribute("type") || input.type || "").toLowerCase();
+
+const parseInputDate = input => {
+    const type = getInputType(input);
+
+    if (!input.value) {
+        return new Date();
+    }
+
+    if (type === "date") {
+        return new Date(`${input.value}T00:00:00`);
+    }
+
+    if (type === "datetime-local") {
+        return new Date(input.value);
+    }
+
+    return new Date();
+};
+
+const formatUtcValue = input => {
+    let date = parseInputDate(input);
+
+    if (Number.isNaN(date.getTime())) {
+        date = new Date();
+    }
+
+    const type = getInputType(input);
+
+    if (type === "date") {
+        return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+    }
+
+    if (type === "datetime-local") {
+        const isoString = date.toISOString();
+        const includeSeconds = input.value ? input.value.length > 16 : false;
+        return includeSeconds ? isoString.slice(0, 19) : isoString.slice(0, 16);
+    }
+
+    return null;
+};
+
+const configureUtcButtons = () => {
+    const utcButtons = document.querySelectorAll("[data-utc-target]");
+
+    utcButtons.forEach(button => {
+        const { utcTarget } = button.dataset;
+        const input = document.getElementById(utcTarget);
+        const type = input ? getInputType(input) : "";
+
+        if (!input || !(type === "date" || type === "datetime-local")) {
+            return;
+        }
+
+        button.addEventListener("click", () => {
+            const utcValue = formatUtcValue(input);
+
+            if (!utcValue) {
+                return;
+            }
+
+            input.value = utcValue;
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+            input.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+    });
+};
+
 configureDropdownToggle(divisionsToggle, divisionsDropDown);
 configureDropdownToggle(pToolsToggle, pToolsDropDown);
+configureUtcButtons();
 

--- a/src/pages/PaperworkTools/code1Reports.html
+++ b/src/pages/PaperworkTools/code1Reports.html
@@ -107,12 +107,19 @@
               <div class="label">
                 <label for="DateTimeUTC">Date and Time (UTC):</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input
                   type="datetime-local"
                   name="DateTimeUTC"
                   id="DateTimeUTC"
                 />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="DateTimeUTC"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 

--- a/src/pages/PaperworkTools/dutyReports.html
+++ b/src/pages/PaperworkTools/dutyReports.html
@@ -107,8 +107,15 @@
               <div class="label">
                 <label for="Date">Date of Report:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="date" name="DateOfReport" id="DateOfReport" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="DateOfReport"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 

--- a/src/pages/PaperworkTools/force6Reports.html
+++ b/src/pages/PaperworkTools/force6Reports.html
@@ -107,8 +107,15 @@
               <div class="label">
                 <label for="Date">Date:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="date" name="Date" id="Date" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="Date"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 

--- a/src/pages/PaperworkTools/solitaryReports.html
+++ b/src/pages/PaperworkTools/solitaryReports.html
@@ -110,8 +110,15 @@
               <div class="label">
                 <label for="DateTime">Date and Time (UTC):</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="datetime-local" name="DateTime" id="DateTime" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="DateTime"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 

--- a/src/pages/SupervisorTools/supervisorDutyReports.html
+++ b/src/pages/SupervisorTools/supervisorDutyReports.html
@@ -121,8 +121,15 @@
               <div class="label">
                 <label for="Date">Date of Report:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="date" name="DateOfReport" id="DateOfReport" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="DateOfReport"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 

--- a/src/styles/reports/DutyReprots.css
+++ b/src/styles/reports/DutyReprots.css
@@ -24,6 +24,24 @@ form[id$="ReportsForm"] .form-group .inputs {
     width: 100%;
 }
 
+form[id$="ReportsForm"] .inputs--with-utc {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+form[id$="ReportsForm"] .inputs--with-utc > input,
+form[id$="ReportsForm"] .inputs--with-utc > textarea,
+form[id$="ReportsForm"] .inputs--with-utc > select {
+    flex: 1 1 auto;
+}
+
+form[id$="ReportsForm"] .inputs--with-utc > .set-utc-btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
 form[id$="ReportsForm"] input,
 form[id$="ReportsForm"] textarea,
 form[id$="ReportsForm"] select {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -343,6 +343,24 @@ form[id$="ReportsForm"] .form-group .inputs {
     width: 100%;
 }
 
+form[id$="ReportsForm"] .inputs--with-utc {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+form[id$="ReportsForm"] .inputs--with-utc > input,
+form[id$="ReportsForm"] .inputs--with-utc > textarea,
+form[id$="ReportsForm"] .inputs--with-utc > select {
+    flex: 1 1 auto;
+}
+
+form[id$="ReportsForm"] .inputs--with-utc > .set-utc-btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
 form[id$="ReportsForm"] input,
 form[id$="ReportsForm"] textarea,
 form[id$="ReportsForm"] select {


### PR DESCRIPTION
## Summary
- add "Set UTC" controls next to each report date/datetime field so they can be filled automatically
- convert local values to UTC through a shared helper and keep field persistence in sync
- adjust report form styling to lay out the new buttons beside their inputs

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68cb4cf195e8833080826d413f92af7f