### PR TITLE
Keep UTC button aligned with input

### DIFF
--- a/src/styles/reports/DutyReprots.css
+++ b/src/styles/reports/DutyReprots.css
@@ -28,13 +28,14 @@ form[id$="ReportsForm"] .inputs--with-utc {
     display: flex;
     gap: 8px;
     align-items: center;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 form[id$="ReportsForm"] .inputs--with-utc > input,
 form[id$="ReportsForm"] .inputs--with-utc > textarea,
 form[id$="ReportsForm"] .inputs--with-utc > select {
     flex: 1 1 auto;
+    min-width: 0;
 }
 
 form[id$="ReportsForm"] .inputs--with-utc > .set-utc-btn {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -347,13 +347,14 @@ form[id$="ReportsForm"] .inputs--with-utc {
     display: flex;
     gap: 8px;
     align-items: center;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 form[id$="ReportsForm"] .inputs--with-utc > input,
 form[id$="ReportsForm"] .inputs--with-utc > textarea,
 form[id$="ReportsForm"] .inputs--with-utc > select {
     flex: 1 1 auto;
+    min-width: 0;
 }
 
 form[id$="ReportsForm"] .inputs--with-utc > .set-utc-btn {


### PR DESCRIPTION
## Summary
- prevent the Set UTC button from wrapping under the date/time field by keeping the input row from flex-wrapping
- allow the input to shrink with the button so both controls stay aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb509064ac8330bf1fe74fa5b10ef6