### PR TITLE
Add UTC buttons for shift times

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,15 @@ const formatUtcValue = input => {
         return includeSeconds ? isoString.slice(0, 19) : isoString.slice(0, 16);
     }
 
+    if (type === "time") {
+        const includeSeconds = input.value ? input.value.length > 5 : false;
+        const hours = pad(date.getUTCHours());
+        const minutes = pad(date.getUTCMinutes());
+        const seconds = pad(date.getUTCSeconds());
+
+        return includeSeconds ? `${hours}:${minutes}:${seconds}` : `${hours}:${minutes}`;
+    }
+
     return null;
 };
 
@@ -81,7 +90,7 @@ const configureUtcButtons = () => {
         const input = document.getElementById(utcTarget);
         const type = input ? getInputType(input) : "";
 
-        if (!input || !(type === "date" || type === "datetime-local")) {
+        if (!input || !(type === "date" || type === "datetime-local" || type === "time")) {
             return;
         }
 

--- a/src/pages/PaperworkTools/dutyReports.html
+++ b/src/pages/PaperworkTools/dutyReports.html
@@ -123,8 +123,15 @@
               <div class="label">
                 <label for="StartOfShift">Start of Shift:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="time" name="StartOfShift" id="StartOfShift" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="StartOfShift"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 
@@ -141,8 +148,15 @@
               <div class="label">
                 <label for="EndOfShift">End of Shift:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="time" name="EndOfShift" id="EndOfShift" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="EndOfShift"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 

--- a/src/pages/SupervisorTools/supervisorDutyReports.html
+++ b/src/pages/SupervisorTools/supervisorDutyReports.html
@@ -137,8 +137,15 @@
               <div class="label">
                 <label for="StartOfShift">Start of Shift:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="time" name="StartOfShift" id="StartOfShift" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="StartOfShift"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 
@@ -146,8 +153,15 @@
               <div class="label">
                 <label for="EndOfShift">End of Shift:</label>
               </div>
-              <div class="inputs">
+              <div class="inputs inputs--with-utc">
                 <input type="time" name="EndOfShift" id="EndOfShift" />
+                <button
+                  type="button"
+                  class="set-utc-btn"
+                  data-utc-target="EndOfShift"
+                >
+                  Set UTC
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add Set UTC shortcuts to the start and end of shift fields on the duty report pages
- update the shared UTC button helper to support time inputs so the new buttons populate UTC values

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb52289e648330a97e889fed4e59a7