### PR TITLE
Add breadcrumb navigation across site pages

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -103,6 +103,11 @@
 
       <div class="content">
         <div class="content-header">
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li><span aria-current="page">Home</span></li>
+            </ol>
+          </nav>
           <h1>San Andreas Department of Corrections Tools</h1>
         </div>
 

--- a/src/pages/PaperworkTools/code1Reports.html
+++ b/src/pages/PaperworkTools/code1Reports.html
@@ -96,6 +96,13 @@
 
       <div class="content">
         <div class="content-header">
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="../../index.html">Home</a></li>
+              <li><span>Paperwork Tools</span></li>
+              <li><span aria-current="page">Code 1 Reports</span></li>
+            </ol>
+          </nav>
           <h1>Code 1 Reports</h1>
         </div>
 

--- a/src/pages/PaperworkTools/dutyReports.html
+++ b/src/pages/PaperworkTools/dutyReports.html
@@ -96,6 +96,13 @@
 
       <div class="content">
         <div class="content-header">
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="../../index.html">Home</a></li>
+              <li><span>Paperwork Tools</span></li>
+              <li><span aria-current="page">Duty Reports</span></li>
+            </ol>
+          </nav>
           <h1>Duty Reports</h1>
         </div>
 

--- a/src/pages/PaperworkTools/force6Reports.html
+++ b/src/pages/PaperworkTools/force6Reports.html
@@ -96,6 +96,13 @@
 
       <div class="content">
         <div class="content-header">
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="../../index.html">Home</a></li>
+              <li><span>Paperwork Tools</span></li>
+              <li><span aria-current="page">Force 6 Reports</span></li>
+            </ol>
+          </nav>
           <h1>Force 6 Reports</h1>
         </div>
 

--- a/src/pages/PaperworkTools/solitaryReports.html
+++ b/src/pages/PaperworkTools/solitaryReports.html
@@ -99,6 +99,13 @@
 
       <div class="content">
         <div class="content-header">
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="../../index.html">Home</a></li>
+              <li><span>Paperwork Tools</span></li>
+              <li><span aria-current="page">Solitary Reports</span></li>
+            </ol>
+          </nav>
           <h1>Solitary Reports</h1>
         </div>
 

--- a/src/pages/SupervisorTools/supervisorDutyReports.html
+++ b/src/pages/SupervisorTools/supervisorDutyReports.html
@@ -110,6 +110,13 @@
 
       <div class="content">
         <div class="content-header">
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="../../index.html">Home</a></li>
+              <li><span>Supervisor Tools</span></li>
+              <li><span aria-current="page">Supervisor Duty Reports</span></li>
+            </ol>
+          </nav>
           <h1>Supervisor Duty Reports</h1>
         </div>
 

--- a/src/styles/Global.css
+++ b/src/styles/Global.css
@@ -80,6 +80,46 @@ button:active {
     border-bottom: 2px solid var(--primary);
 }
 
+.breadcrumbs {
+    margin-bottom: 12px;
+    font-size: 0.95rem;
+}
+
+.breadcrumbs ol {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: var(--text-secondary);
+}
+
+.breadcrumbs li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.breadcrumbs li + li::before {
+    content: "/";
+    color: var(--text-secondary);
+}
+
+.breadcrumbs a {
+    color: var(--light);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.breadcrumbs a:hover,
+.breadcrumbs a:focus {
+    color: var(--accent-teal);
+}
+
+.breadcrumbs [aria-current="page"] {
+    color: var(--light);
+    font-weight: 600;
+}
+
 .content-body {
     padding: 30px;
     background-color: var(--bg-dark-tertiary);


### PR DESCRIPTION
## Summary
- add global breadcrumb styling for consistent presentation
- inject breadcrumb navigation into the home page and each reports page

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc2982c3948330b67ea8e2e3a68f9b